### PR TITLE
Fix sidebar icon visibility

### DIFF
--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -46,6 +46,13 @@ const items = [
 .icon {
   width: 24px;
   height: 24px;
+  flex-shrink: 0;
+  fill: currentColor;
+}
+
+.nav-item:hover .icon {
+  background-color: #555;
+  border-radius: 4px;
 }
 .nav-item span {
   margin-left: 1rem;


### PR DESCRIPTION
## Summary
- keep sidebar icons visible
- add light gray icon hover background

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68579c6541348330a61d71855dec1d30